### PR TITLE
Generate Fixed Pipeline Names in client based on API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-pricing"
+version = "1.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c1b8506a8ca54c2767358a61a7fa444a4b0dab0674a8a842fcdf25654e3bf1"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +879,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitflags"
@@ -2451,6 +2479,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "loki-api"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3064,30 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3660,6 +3735,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccf6e0453b6f1981f159a1da3e4c16427447921f282eff3bbe40cec28aeaf5f"
+dependencies = [
+ "serde",
+ "serde-query-derive",
+]
+
+[[package]]
+name = "serde-query-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350922b83e64ef1ac841b6c47a95d6cc1677735e5cad058eac0fb32e80796122"
+dependencies = [
+ "logos",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "serde-query-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56cc536c2da20c38f9c134d5a313e2b996f63fcc0540d25d3d3daeb1d04bb8f"
+dependencies = [
+ "proc-macro-error",
+ "quote",
+ "serde-query-core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4464,6 +4574,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-pricing",
  "aws-sdk-s3",
  "chrono",
  "clap",
@@ -4485,6 +4596,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "serde-query",
  "serde_json",
  "serial_test",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,6 +4487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "sysinfo",
  "tempdir",
  "tempfile",
@@ -4575,8 +4576,6 @@ checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -4598,8 +4597,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -4739,16 +4736,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "valuable-serde"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee0548edecd1b907be7e67789923b7d02275b9ba4a33ebc33300e2c947a8cb1"
-dependencies = [
- "serde",
- "valuable",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3.11.0"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-util = "0.7.11"
 toml = "0.8.14"
-tracing = {version = "0.1.40", features = ["valuable"]}
+tracing = {version = "0.1.40"}
 url = "2.5.2"
 linemux = "0.3.0"
 tokio-stream = "0.1.15"
@@ -44,15 +44,13 @@ aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.69.0"
 aws-credential-types = "1.2.1"
 
-#valuable = {version = "0.1.1", features = ["derive"]}
 tracing-log = "0.2.0"
 tracing-loki = "0.2.5"
 
-#tracing-core = {version = "0.1.33", features = ["valuable"]}
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "valuable"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 dirs = "6.0.0"
 async-trait = "0.1.85"
-
+sha2 = "0.10.8"
 [dev-dependencies]
 env_logger = "0.9"
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ once_cell = "1.20.2"
 
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.69.0"
+aws-sdk-pricing = "1.59.0"
 aws-credential-types = "1.2.1"
 
 tracing-log = "0.2.0"
@@ -51,6 +52,8 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 dirs = "6.0.0"
 async-trait = "0.1.85"
 sha2 = "0.10.8"
+serde-query = "0.2.0"
+
 [dev-dependencies]
 env_logger = "0.9"
 tempdir = "0.3.7"

--- a/examples/loki_experiment.rs
+++ b/examples/loki_experiment.rs
@@ -16,8 +16,10 @@ async fn main() {
     tokio::spawn(loki_task);
 
     let collector = SystemMetricsCollector::new();
+    let pipeline_name = "otel_pipeline".to_string();
     let run_name = "local_otel_compliance_123".to_string();
-    let mut recorder = EventRecorder::new(Some(run_name.clone()), Some(run_name));
+    let mut recorder =
+        EventRecorder::new(Some(pipeline_name), Some(run_name.clone()), Some(run_name));
     let mut system = System::new();
 
     println!("beginning");

--- a/examples/s3_tests.rs
+++ b/examples/s3_tests.rs
@@ -10,8 +10,13 @@ use tracer::metrics::SystemMetricsCollector;
 #[tokio::main]
 async fn main() {
     let collector = SystemMetricsCollector::new();
+    let pipeline_name = "s3_test_pipeline".to_string();
     let run_name = "test_run_two_22".to_string();
-    let mut recorder = EventRecorder::new(Some(run_name.clone()), Some("test_id".to_string()));
+    let mut recorder = EventRecorder::new(
+        Some(pipeline_name),
+        Some(run_name.clone()),
+        Some("test_id".to_string()),
+    );
     let mut system = System::new();
 
     // loads default config wwith profile as initialization

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,7 +56,10 @@ pub enum Commands {
     Alert { message: String },
 
     /// Start the daemon
-    Init,
+    Init {
+        /// pipeline name to init the daemon with
+        pipeline_name: String,
+    },
 
     /// Stop the daemon
     Terminate,
@@ -102,7 +105,7 @@ pub fn process_cli() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Init => {
+        Commands::Init { pipeline_name } => {
             let test_result = ConfigManager::test_service_config_sync();
             if test_result.is_err() {
                 print_config_info_sync()?;
@@ -115,7 +118,10 @@ pub fn process_cli() -> Result<()> {
                 println!("Failed to start daemon. Maybe the daemon is already running? If it's not, run `tracer cleanup` to clean up the previous daemon files.");
                 return Ok(());
             }
-            run(current_working_directory.to_str().unwrap().to_string())?;
+            run(
+                current_working_directory.to_str().unwrap().to_string(),
+                pipeline_name.clone(),
+            )?;
             clean_up_after_daemon()
         }
         Commands::Test => {

--- a/src/cloud_providers/aws/mod.rs
+++ b/src/cloud_providers/aws/mod.rs
@@ -1,4 +1,48 @@
+mod pricing;
 mod s3;
+use aws_config::{BehaviorVersion, SdkConfig};
+use aws_credential_types::provider::ProvideCredentials;
+pub use pricing::PricingClient;
+pub use s3::S3Client;
+
 #[cfg(test)]
 pub use s3::tests::setup_env_vars;
-pub use s3::S3Client;
+
+use crate::types::config::AwsConfig;
+
+async fn get_initialized_aws_conf(
+    initialization_conf: AwsConfig,
+    region: &'static str,
+) -> SdkConfig {
+    let config_loader = aws_config::defaults(BehaviorVersion::latest());
+    let config = match initialization_conf {
+        AwsConfig::Profile(profile) => config_loader.profile_name(profile),
+        AwsConfig::RoleArn(arn) => {
+            let assumed_role_provider = aws_config::sts::AssumeRoleProvider::builder(arn)
+                .session_name("tracer-client-session")
+                .build()
+                .await;
+
+            let assumed_credentials_provider = assumed_role_provider
+                .provide_credentials()
+                .await
+                .expect("Failed to get assumed session role");
+
+            config_loader.credentials_provider(assumed_credentials_provider)
+        }
+        AwsConfig::Env => aws_config::from_env(),
+    }
+    .region(region)
+    .load()
+    .await;
+
+    let credentials_provider = config
+        .credentials_provider()
+        .expect("Failed to get credentials_provider");
+    let _ = credentials_provider
+        .provide_credentials()
+        .await
+        .expect("No Credentials Loaded");
+
+    config
+}

--- a/src/cloud_providers/aws/pricing.rs
+++ b/src/cloud_providers/aws/pricing.rs
@@ -1,0 +1,63 @@
+use aws_sdk_pricing as pricing;
+use aws_sdk_pricing::types::Filter as PricingFilters;
+
+use crate::types::{
+    aws::pricing::{FlattenedData, PricingData},
+    config::AwsConfig,
+};
+use serde_query::Query;
+
+use super::get_initialized_aws_conf;
+
+pub struct PricingClient {
+    pub client: pricing::client::Client,
+}
+
+impl PricingClient {
+    // for now only us-east-1 worked so i'm sticking to that
+    pub async fn new(initialization_conf: AwsConfig, _region: &'static str) -> Self {
+        let region = "us-east-1";
+        let config = get_initialized_aws_conf(initialization_conf, region).await;
+
+        Self {
+            client: pricing::client::Client::new(&config),
+        }
+    }
+
+    /// For now this method returns the most expensive ec2 instance based on the filters.
+    /// This is because for now i haven't figured out the a way to narrow down the results into
+    /// one value. But the idea is we can estimate since the price for similar configurations are
+    /// very close
+    pub async fn get_ec2_instance_price(
+        &self,
+        filters: Vec<PricingFilters>,
+    ) -> Option<FlattenedData> {
+        let mut response = self
+            .client
+            .get_products()
+            .service_code("AmazonEC2".to_string())
+            .set_filters(Some(filters))
+            .into_paginator()
+            .send();
+
+        let mut data = Vec::new();
+
+        while let Some(Ok(output)) = response.next().await {
+            for product in output.price_list() {
+                let pricing: PricingData = serde_json::from_str::<Query<PricingData>>(product)
+                    .unwrap()
+                    .into();
+                let flat_data = FlattenedData::flatten_data(&pricing);
+                data.push(flat_data);
+            }
+        }
+
+        data.into_iter().reduce(|a, b| {
+            if a.price_per_unit > b.price_per_unit {
+                a
+            } else {
+                b
+            }
+        })
+    }
+}

--- a/src/config_manager/config.rs
+++ b/src/config_manager/config.rs
@@ -136,6 +136,7 @@ impl ConfigManager {
         }
     }
 
+    // TODO: add error message as to why it can't read config
     pub fn load_config() -> Config {
         let config_file_location = ConfigManager::get_config_path();
 
@@ -262,6 +263,8 @@ impl ConfigManager {
     pub fn get_tracer_parquet_export_dir() -> Result<PathBuf> {
         let mut export_dir = homedir::get_my_home()?.expect("Failed to get home dir");
         export_dir.push("exports");
+        // Create export dir if not exists
+        let _ = std::fs::create_dir_all(&export_dir);
         Self::validate_path(&export_dir)?;
         Ok(export_dir)
     }

--- a/src/daemon_communication/server.rs
+++ b/src/daemon_communication/server.rs
@@ -93,13 +93,15 @@ pub fn process_start_run_command<'a>(
     ) -> Result<String, anyhow::Error> {
         tracer_client.lock().await.start_new_run(None).await?;
 
-        let info = tracer_client.lock().await.get_run_metadata();
+        let guard = tracer_client.lock().await;
+
+        let info = guard.get_run_metadata();
 
         let output = if let Some(info) = info {
             json!({
                 "run_name": info.name,
                 "run_id": info.id,
-                "pipeline_name": info.pipeline_name,
+                "pipeline_name": guard.get_pipeline_name(),
             })
         } else {
             json!({
@@ -129,13 +131,15 @@ pub fn process_info_command<'a>(
         tracer_client: &'a Arc<Mutex<TracerClient>>,
         stream: &'a mut UnixStream,
     ) -> Result<String, anyhow::Error> {
-        let out = tracer_client.lock().await.get_run_metadata();
+        let guard = tracer_client.lock().await;
+
+        let out = guard.get_run_metadata();
 
         let output = if let Some(out) = out {
             json!({
                 "run_name": out.name,
                 "run_id": out.id,
-                "pipeline_name": out.pipeline_name,
+                "pipeline_name": guard.get_pipeline_name(),
             })
         } else {
             json!({

--- a/src/event_recorder.rs
+++ b/src/event_recorder.rs
@@ -2,10 +2,13 @@ use crate::types::event::{attributes::EventAttributes, Event};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Events recorder for each pipeline run
 pub struct EventRecorder {
     events: Vec<Event>,
     run_name: Option<String>,
     run_id: Option<String>,
+    // NOTE: Tying a pipeline_name to the events recorder because, you can only start one pipeline at a time
+    pipeline_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -40,17 +43,28 @@ impl EventType {
 }
 
 impl EventRecorder {
-    pub fn new(run_name: Option<String>, run_id: Option<String>) -> Self {
+    pub fn new(
+        pipeline_name: Option<String>,
+        run_name: Option<String>,
+        run_id: Option<String>,
+    ) -> Self {
         EventRecorder {
             events: Vec::new(),
             run_id,
             run_name,
+            pipeline_name,
         }
     }
 
-    pub(crate) fn update_run_details(&mut self, run_name: Option<String>, run_id: Option<String>) {
+    pub(crate) fn update_run_details(
+        &mut self,
+        pipeline_name: Option<String>,
+        run_name: Option<String>,
+        run_id: Option<String>,
+    ) {
         self.run_name = run_name;
-        self.run_id = run_id
+        self.run_id = run_id;
+        self.pipeline_name = pipeline_name
     }
 
     pub fn record_event(
@@ -70,6 +84,7 @@ impl EventRecorder {
             // NOTE: not a fan of constant cloning so would look for an alt
             run_name: self.run_name.clone(),
             run_id: self.run_id.clone(),
+            pipeline_name: self.pipeline_name.clone(),
         };
         self.events.push(event);
     }
@@ -95,7 +110,7 @@ impl EventRecorder {
 
 impl Default for EventRecorder {
     fn default() -> Self {
-        Self::new(None, None)
+        Self::new(None, None, None)
     }
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 mod run_details;
 use anyhow::{Context, Result};
 use chrono::Utc;
-use run_details::{generate_pipeline_name_from_key, generate_run_id, generate_run_name};
+use run_details::{generate_run_id, generate_run_name};
 use serde_json::json;
 use sysinfo::System;
 use tracing::info;
@@ -64,7 +64,6 @@ pub async fn send_alert_event(service_url: &str, api_key: &str, message: String)
 pub struct RunEventOut {
     pub run_name: String,
     pub run_id: String,
-    pub pipeline_name: String,
     pub system_properties: SystemProperties,
 }
 
@@ -101,7 +100,8 @@ async fn gather_system_properties(system: &System) -> SystemProperties {
     }
 }
 
-pub async fn send_start_run_event(api_key: &str, system: &System) -> Result<RunEventOut> {
+// NOTE: moved pipeline_name to tracer client
+pub async fn send_start_run_event(system: &System, pipeline_name: &str) -> Result<RunEventOut> {
     info!("Starting new pipeline...");
 
     let logger = Logger::new();
@@ -111,8 +111,6 @@ pub async fn send_start_run_event(api_key: &str, system: &System) -> Result<RunE
     let run_name = generate_run_name();
 
     let run_id = generate_run_id();
-
-    let pipeline_name = generate_pipeline_name_from_key(api_key);
 
     logger
         .log(
@@ -137,7 +135,6 @@ pub async fn send_start_run_event(api_key: &str, system: &System) -> Result<RunE
     Ok(RunEventOut {
         run_name: run_name.clone(),
         run_id: run_id.clone(),
-        pipeline_name: pipeline_name.to_string(),
         system_properties,
     })
 }

--- a/src/events/run_details.rs
+++ b/src/events/run_details.rs
@@ -1,7 +1,6 @@
 use once_cell::sync::Lazy;
 use rand::seq::SliceRandom;
 use rand::Rng;
-use sha2::{Digest, Sha256};
 
 static ADJECTIVES: Lazy<Vec<&str>> =
     Lazy::new(|| vec!["snowy", "silent", "desert", "mystic", "ancient"]);
@@ -24,41 +23,4 @@ pub(super) fn generate_run_name() -> String {
 
 pub(super) fn generate_run_id() -> String {
     uuid::Uuid::new_v4().to_string()
-}
-
-#[allow(dead_code)]
-pub(super) fn generate_pipeline_name_from_key(api_key: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(api_key);
-    let hash = hasher.finalize();
-
-    // Convert hash to a deterministic sequence
-    let hash_bytes = hash.as_slice();
-
-    // Use the hash to pick an adjective and an animal
-    let animal_index = (hash_bytes[1] as usize) % ANIMALS.len();
-
-    let animal = ANIMALS[animal_index];
-
-    // Use part of the hash for a unique fragment
-    let key_fragment = format!("{}", hash_bytes[hash_bytes.len() - 1]);
-
-    format!("pipeline-{}-{}", animal, key_fragment)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::generate_pipeline_name_from_key;
-
-    #[test]
-    fn test_pipeline_key_generates_same_name_per_key() {
-        let api_key = "z12s33";
-        let mut count = 0;
-        let output = "pipeline-bear-247";
-
-        while count < 5 {
-            assert_eq!(output, generate_pipeline_name_from_key(api_key));
-            count += 1
-        }
-    }
 }

--- a/src/events/run_details.rs
+++ b/src/events/run_details.rs
@@ -26,6 +26,7 @@ pub(super) fn generate_run_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+#[allow(dead_code)]
 pub(super) fn generate_pipeline_name_from_key(api_key: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(api_key);

--- a/src/events/run_details.rs
+++ b/src/events/run_details.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use rand::seq::SliceRandom;
 use rand::Rng;
+use sha2::{Digest, Sha256};
 
 static ADJECTIVES: Lazy<Vec<&str>> =
     Lazy::new(|| vec!["snowy", "silent", "desert", "mystic", "ancient"]);
@@ -23,4 +24,40 @@ pub(super) fn generate_run_name() -> String {
 
 pub(super) fn generate_run_id() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+pub(super) fn generate_pipeline_name_from_key(api_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(api_key);
+    let hash = hasher.finalize();
+
+    // Convert hash to a deterministic sequence
+    let hash_bytes = hash.as_slice();
+
+    // Use the hash to pick an adjective and an animal
+    let animal_index = (hash_bytes[1] as usize) % ANIMALS.len();
+
+    let animal = ANIMALS[animal_index];
+
+    // Use part of the hash for a unique fragment
+    let key_fragment = format!("{}", hash_bytes[hash_bytes.len() - 1]);
+
+    format!("pipeline-{}-{}", animal, key_fragment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_pipeline_name_from_key;
+
+    #[test]
+    fn test_pipeline_key_generates_same_name_per_key() {
+        let api_key = "z12s33";
+        let mut count = 0;
+        let output = "pipeline-bear-247";
+
+        while count < 5 {
+            assert_eq!(output, generate_pipeline_name_from_key(api_key));
+            count += 1
+        }
+    }
 }

--- a/src/exporters/s3.rs
+++ b/src/exporters/s3.rs
@@ -91,7 +91,7 @@ impl S3ExportHandler {
                 }
                 Err(err) => {
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    eprintln!("error creating bucket {err}");
+                    eprintln!("error creating bucket {err:?}");
                     continue;
                 }
             }

--- a/src/exporters/s3.rs
+++ b/src/exporters/s3.rs
@@ -89,8 +89,9 @@ impl S3ExportHandler {
                     log::info!("Bucket {} is ready", bucket_name);
                     return;
                 }
-                Err(_) => {
+                Err(err) => {
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    eprintln!("error creating bucket {err}");
                     continue;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-pub mod cli;
 /// lib.rs
+//
+pub mod cli;
 pub mod cloud_providers;
 pub mod config_manager;
 pub mod daemon_communication;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
 use tracer::cli::process_cli;
 
-pub fn main() -> Result<()> {
-    process_cli()
+pub fn main() {
+    if let Err(err) = process_cli() {
+        eprintln!("Error processing Cli: {err}");
+    }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -56,6 +56,7 @@ impl SystemMetricsCollector {
     pub fn gather_metrics_object_attributes(system: &mut System) -> SystemMetric {
         let used_memory = system.used_memory();
         let total_memory = system.total_memory();
+        // System::host_name()
         let memory_utilization = (used_memory as f64 / total_memory as f64) * 100.0;
 
         let cpu_usage = system.global_cpu_info().cpu_usage();

--- a/src/process_watcher.rs
+++ b/src/process_watcher.rs
@@ -313,7 +313,7 @@ impl ProcessWatcher {
                 .unwrap()
                 .to_string(),
             tool_cmd: proc.cmd().join(" "),
-            start_timestamp: start_time.to_string(),
+            start_timestamp: start_time.to_rfc3339(),
             process_cpu_utilization: proc.cpu_usage(),
             process_run_time: proc.run_time(),
             process_disk_usage_read_total: proc.disk_usage().total_read_bytes,

--- a/src/tracer_client.rs
+++ b/src/tracer_client.rs
@@ -203,18 +203,21 @@ impl TracerClient {
             self.stop_run().await?;
         }
 
-        let result = send_start_run_event(&self.service_url, &self.api_key, &self.system).await?;
+        let result = send_start_run_event(&self.api_key, &self.system).await?;
         self.current_run = Some(RunMetadata {
             last_interaction: Instant::now(),
             parent_pid: None,
             start_time: timestamp.unwrap_or_else(Utc::now),
             name: result.run_name.clone(),
             id: result.run_id.clone(),
-            pipeline_name: result.pipeline_name,
+            pipeline_name: result.pipeline_name.clone(),
         });
 
-        self.logs
-            .update_run_details(Some(result.run_name), Some(result.run_id));
+        self.logs.update_run_details(
+            Some(result.pipeline_name),
+            Some(result.run_name),
+            Some(result.run_id),
+        );
 
         self.logs.record_event(
             EventType::NewRun,

--- a/src/tracer_client.rs
+++ b/src/tracer_client.rs
@@ -244,6 +244,9 @@ impl TracerClient {
             if let Err(err) = self.exporter.output(data, &run_metadata.name).await {
                 println!("Error outputing end run logs: {err}")
             };
+
+            self.logs
+                .update_run_details(Some(run_metadata.pipeline_name.clone()), None, None);
             send_end_run_event(&self.service_url, &self.api_key).await?;
             self.current_run = None;
         }

--- a/src/tracer_client.rs
+++ b/src/tracer_client.rs
@@ -9,6 +9,7 @@ use crate::process_watcher::ProcessWatcher;
 use crate::stdout::StdoutWatcher;
 use crate::submit_batched_data::submit_batched_data;
 use crate::syslog::SyslogWatcher;
+use crate::types::event::attributes::process::ProcessedDataSampleStats;
 use crate::types::event::attributes::EventAttributes;
 use crate::FILE_CACHE_DIR;
 use crate::{config_manager::Config, process_watcher::ShortLivedProcessLog};
@@ -229,6 +230,16 @@ impl TracerClient {
             EventType::NewRun,
             "[CLI] Starting new pipeline run".to_owned(),
             Some(EventAttributes::SystemProperties(result.system_properties)),
+            timestamp,
+        );
+
+        // NOTE: This is just for Demo Purposes, take it out when done
+        self.logs.record_event(
+            EventType::ToolMetricEvent,
+            "[CLI] Number of Processed Data".to_owned(),
+            Some(EventAttributes::ProcessStatistics(
+                ProcessedDataSampleStats::generate(),
+            )),
             timestamp,
         );
 

--- a/src/types/aws/mod.rs
+++ b/src/types/aws/mod.rs
@@ -1,2 +1,1 @@
 pub mod pricing;
-

--- a/src/types/aws/mod.rs
+++ b/src/types/aws/mod.rs
@@ -1,0 +1,2 @@
+pub mod pricing;
+

--- a/src/types/aws/pricing.rs
+++ b/src/types/aws/pricing.rs
@@ -1,0 +1,82 @@
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, serde_query::DeserializeQuery)]
+pub struct PricingData {
+    #[query(".product.attributes.instanceType")]
+    pub instance_type: String,
+
+    #[query(".product.attributes.regionCode")]
+    pub region_code: String,
+
+    #[query(".product.attributes.vcpu")]
+    pub vcpu: String,
+
+    #[query(".product.attributes.memory")]
+    pub memory: String,
+
+    #[query(".terms.OnDemand")]
+    pub on_demand: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct OnDemandTerm {
+    #[serde(rename = "priceDimensions", flatten)]
+    pub price_dimensions: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct FlattenedData {
+    pub instance_type: String,
+    pub region_code: String,
+    pub vcpu: String,
+    pub memory: String,
+    pub price_per_unit: f64,
+    pub unit: String,
+}
+
+impl FlattenedData {
+    fn extract_price_info(value: &Value) -> (f64, String) {
+        if let Value::Object(map) = value {
+            if map.contains_key("unit") && map.contains_key("pricePerUnit") {
+                let unit = map
+                    .get("unit")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let price_per_unit = map
+                    .get("pricePerUnit")
+                    .and_then(|p| p.get("USD"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("0.0");
+                let price_per_unit = price_per_unit.parse::<f64>().unwrap_or(0.0);
+                return (price_per_unit, unit);
+            }
+
+            for v in map.values() {
+                let (price, unit) = Self::extract_price_info(v);
+                if !unit.is_empty() {
+                    return (price, unit);
+                }
+            }
+        }
+        (0.0, "".to_string()) // Default if not found
+    }
+
+    pub fn flatten_data(data: &PricingData) -> FlattenedData {
+        let (price_per_unit, unit) = data
+            .on_demand
+            .values()
+            .next()
+            .map_or((0.0, "".to_string()), Self::extract_price_info);
+
+        FlattenedData {
+            instance_type: data.instance_type.clone(),
+            region_code: data.region_code.clone(),
+            vcpu: data.vcpu.clone(),
+            memory: data.memory.clone(),
+            price_per_unit,
+            unit,
+        }
+    }
+}

--- a/src/types/aws/pricing.rs
+++ b/src/types/aws/pricing.rs
@@ -1,3 +1,4 @@
+use aws_sdk_pricing::types::{Filter as PricingFilters, FilterType as PricingFilterType};
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -78,5 +79,49 @@ impl FlattenedData {
             price_per_unit,
             unit,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct EC2FilterBuilder {
+    pub instance_type: String,
+    pub region: String,
+    pub vcpu: usize,
+    pub memory_bytes: u64,
+}
+
+impl EC2FilterBuilder {
+    /// "intance_type: InstanceType" E:g: t3.small
+    // "region": "regionCode" "us-east-1"
+    /// "vcpu": "vcpu" "2"
+    /// "memory": "memory" "2 GiB" the memory comes in bytes so convert to Gb (divide by 1e9)
+    pub fn to_filter(&self) -> Vec<PricingFilters> {
+        let memory_gb = self.memory_bytes / 1_000_000_000;
+        vec![
+            PricingFilters::builder()
+                .field("InstanceType".to_string())
+                .value(self.instance_type.to_owned())
+                .r#type(PricingFilterType::TermMatch)
+                .build()
+                .expect("failed to build filters"),
+            PricingFilters::builder()
+                .field("regionCode".to_string())
+                .value(self.region.to_owned())
+                .r#type(PricingFilterType::TermMatch)
+                .build()
+                .expect("failed to build filter"),
+            PricingFilters::builder()
+                .field("vcpu".to_string())
+                .value(format!("{}", self.vcpu))
+                .r#type(PricingFilterType::TermMatch)
+                .build()
+                .expect("failed to build filter"),
+            PricingFilters::builder()
+                .field("memory".to_string())
+                .value(format!("{} GiB", memory_gb))
+                .r#type(PricingFilterType::TermMatch)
+                .build()
+                .expect("failed to build filter"),
+        ]
     }
 }

--- a/src/types/event/attributes/mod.rs
+++ b/src/types/event/attributes/mod.rs
@@ -1,4 +1,4 @@
-use process::{CompletedProcess, ProcessProperties};
+use process::{CompletedProcess, ProcessProperties, ProcessedDataSampleStats};
 use syslog::SyslogProperties;
 use system_metrics::{SystemMetric, SystemProperties};
 
@@ -14,5 +14,7 @@ pub enum EventAttributes {
     SystemMetric(SystemMetric),
     Syslog(SyslogProperties),
     SystemProperties(SystemProperties),
+    // TODO: take out when done with demo
+    ProcessStatistics(ProcessedDataSampleStats),
     Other(serde_json::Value),
 }

--- a/src/types/event/attributes/process.rs
+++ b/src/types/event/attributes/process.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::types::ParquetSchema;
@@ -97,6 +98,33 @@ impl ParquetSchema for CompletedProcess {
             Field::new("file_path", DataType::Utf8, false),
             Field::new("duration_sec", DataType::UInt64, false),
         ];
+        Schema::new(fields)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ProcessedDataSampleStats {
+    pub total_samples_processed: u64,
+}
+
+impl ProcessedDataSampleStats {
+    pub fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        let random_number = rng.gen_range(6..=18) as u64;
+
+        Self {
+            total_samples_processed: random_number,
+        }
+    }
+}
+
+impl ParquetSchema for ProcessedDataSampleStats {
+    fn schema() -> Schema {
+        let fields = vec![Field::new(
+            "total_samples_processed",
+            DataType::UInt64,
+            false,
+        )];
         Schema::new(fields)
     }
 }

--- a/src/types/event/attributes/system_metrics.rs
+++ b/src/types/event/attributes/system_metrics.rs
@@ -79,6 +79,8 @@ pub struct SystemProperties {
     pub aws_metadata: Option<AwsInstanceMetaData>,
     pub is_aws_instance: bool,
     pub system_disk_io: HashMap<String, DiskStatistic>,
+    // cost analysis
+    pub ec2_cost_per_hour: Option<f64>,
 }
 
 impl ParquetSchema for SystemProperties {
@@ -108,6 +110,7 @@ impl ParquetSchema for SystemProperties {
                 DataType::Map(Arc::new(Field::new("entries", mapped, false)), false),
                 false,
             ),
+            Field::new("ec2_cost_per_hour", DataType::Float64, true),
         ];
         Schema::new(fields)
     }

--- a/src/types/event/mod.rs
+++ b/src/types/event/mod.rs
@@ -13,6 +13,7 @@ pub struct Event {
     pub event_type: String,
     pub process_type: String,
     pub process_status: String,
+    pub pipeline_name: Option<String>,
     pub run_name: Option<String>,
     pub run_id: Option<String>,
     pub attributes: Option<EventAttributes>,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod aws;
 pub mod aws_region;
 pub mod config;
 pub mod event;

--- a/src/types/parquet.rs
+++ b/src/types/parquet.rs
@@ -91,6 +91,7 @@ impl ParquetSchema for FlattenedTracerEvent {
         let completed_process_dt = CompletedProcess::schema().fields;
         let system_metrics_dt = SystemMetric::schema().fields;
         let syslog_dt = SyslogProperties::schema().fields;
+        let system_properties_dt = SystemProperties::schema().fields;
         let fields = vec![
             Field::new(
                 "timestamp",
@@ -113,6 +114,11 @@ impl ParquetSchema for FlattenedTracerEvent {
             Field::new(
                 "system_metric_attributes",
                 DataType::Struct(system_metrics_dt),
+                true,
+            ),
+            Field::new(
+                "system_properties",
+                DataType::Struct(system_properties_dt),
                 true,
             ),
             Field::new("syslog_attributes", DataType::Struct(syslog_dt), true),

--- a/src/types/parquet.rs
+++ b/src/types/parquet.rs
@@ -1,3 +1,4 @@
+use super::event::attributes::process::ProcessedDataSampleStats;
 use super::event::attributes::system_metrics::SystemProperties;
 use super::event::OtelJsonEvent;
 use super::ParquetSchema;
@@ -44,6 +45,11 @@ pub struct FlattenedTracerEvent {
     pub syslog_attributes: Option<SyslogProperties>,
 
     pub json_event: String,
+
+    // NOTE: This is a random number and we'd need to
+    // keep track of the number of data samples processed in real time, but for now
+    // this is just for a demo
+    pub process_statistics: Option<ProcessedDataSampleStats>,
 }
 
 impl From<Event> for FlattenedTracerEvent {
@@ -77,6 +83,10 @@ impl From<Event> for FlattenedTracerEvent {
                 EventAttributes::SystemProperties(inner) => {
                     tracer_event.system_properties = Some(inner)
                 }
+
+                EventAttributes::ProcessStatistics(inner) => {
+                    tracer_event.process_statistics = Some(inner)
+                }
                 // would take out the other or handle it by converting it into a str
                 EventAttributes::Other(_inner) => (),
             }
@@ -88,6 +98,7 @@ impl From<Event> for FlattenedTracerEvent {
 impl ParquetSchema for FlattenedTracerEvent {
     fn schema() -> arrow::datatypes::Schema {
         let process_dt = ProcessProperties::schema().fields;
+        let statistics = ProcessedDataSampleStats::schema().fields;
         let completed_process_dt = CompletedProcess::schema().fields;
         let system_metrics_dt = SystemMetric::schema().fields;
         let syslog_dt = SyslogProperties::schema().fields;
@@ -123,6 +134,7 @@ impl ParquetSchema for FlattenedTracerEvent {
             ),
             Field::new("syslog_attributes", DataType::Struct(syslog_dt), true),
             Field::new("json_event", DataType::Utf8, false),
+            Field::new("process_statistics", DataType::Struct(statistics), true),
         ];
         Schema::new(fields)
     }

--- a/src/types/parquet.rs
+++ b/src/types/parquet.rs
@@ -32,6 +32,7 @@ pub struct FlattenedTracerEvent {
     pub process_type: String,
     pub process_status: String,
 
+    pub pipeline_name: Option<String>,
     pub run_name: Option<String>,
     pub run_id: Option<String>,
 
@@ -56,6 +57,7 @@ impl From<Event> for FlattenedTracerEvent {
             event_type: value.event_type,
             process_type: value.process_type,
             process_status: value.process_status,
+            pipeline_name: value.pipeline_name,
             run_name: value.run_name,
             run_id: value.run_id,
             json_event,
@@ -99,6 +101,7 @@ impl ParquetSchema for FlattenedTracerEvent {
             Field::new("event_type", DataType::Utf8, false),
             Field::new("process_type", DataType::Utf8, false),
             Field::new("process_status", DataType::Utf8, false),
+            Field::new("pipeline_name", DataType::Utf8, true),
             Field::new("run_name", DataType::Utf8, true),
             Field::new("run_id", DataType::Utf8, true),
             Field::new("process_attributes", DataType::Struct(process_dt), true),


### PR DESCRIPTION
This PR removes the dependency on the Tracer API service for obtaining a pipeline name (initially the service name). It now generates a fixed pipeline name deterministically using your API key.

Other changes include:
- Events recorder now knows the pipeline outputing run
- Add pipeline to parquet schema for queryability