### PR TITLE
add PricingClient tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,4 +52,7 @@ jobs:
       run: make clippy
 
     - name: Run tests
-      run: make test
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ error_outgoing_http_calls.txt
 log_outgoing_http_calls.txt
 
 debug.log
+
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1400,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "ec2_instance_metadata"
@@ -4453,6 +4481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,6 +4621,7 @@ dependencies = [
  "clap",
  "daemonize",
  "dirs",
+ "dotenv",
  "ec2_instance_metadata",
  "env_logger",
  "futures-util",
@@ -4605,6 +4647,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-test",
  "tokio-util",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,5 @@ serde-query = "0.2.0"
 [dev-dependencies]
 env_logger = "0.9"
 tempdir = "0.3.7"
+dotenv = "0.15"
+tokio-test = "0.4"


### PR DESCRIPTION
# PricingClient tests (In progress - Draft PR)

# Description
The idea is to first run them locally with a .env file that stores the AWS keys.
Then create `test-key` inside aws and add as env variable in github, later use the env variable keys in github actions to allow running pipelines. 

Only one test failed, It's like the response from the client is not in the correct format.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e9eec7bd-8dad-4e86-8da3-5793961accf2" />
